### PR TITLE
Fixed bug for edit after add will cause error in undo.

### DIFF
--- a/src/main/java/mindexpander/commands/AddCommand.java
+++ b/src/main/java/mindexpander/commands/AddCommand.java
@@ -21,6 +21,7 @@ import java.util.List;
  */
 public class AddCommand extends Command implements Multistep, Traceable {
     private Question toAdd;
+    private Question toAddOriginalState;
     private final int toAddIndex;
     private QuestionType type;
     private String question;
@@ -161,6 +162,7 @@ public class AddCommand extends Command implements Multistep, Traceable {
      */
     private Command addFillInTheBlank(QuestionBank questionBank) {
         toAdd = new FillInTheBlanks(question, answer);
+        toAddOriginalState = new FillInTheBlanks((FillInTheBlanks) toAdd);
         questionBank.addQuestion(toAdd);
         QuestionLogger.logAddedQuestion(toAdd);
         updateCommandMessage(String.format("Question %1$s successfully added.", toAdd.toString()));
@@ -197,6 +199,7 @@ public class AddCommand extends Command implements Multistep, Traceable {
         }
 
         toAdd = new MultipleChoice(question, answer, options);
+        toAddOriginalState = new MultipleChoice((MultipleChoice)toAdd);
         questionBank.addQuestion(toAdd);
         QuestionLogger.logAddedQuestion(toAdd);
         updateCommandMessage(String.format("Question %1$s successfully added.", toAdd.toString()));
@@ -218,6 +221,7 @@ public class AddCommand extends Command implements Multistep, Traceable {
             return this;
         }
         toAdd = new TrueFalse(question, answerLower);
+        toAddOriginalState = new TrueFalse((TrueFalse)toAdd);
         questionBank.addQuestion(toAdd);
         QuestionLogger.logAddedQuestion(toAdd);
         updateCommandMessage(String.format("Question %1$s successfully added.", toAdd.toString()));
@@ -226,19 +230,19 @@ public class AddCommand extends Command implements Multistep, Traceable {
     }
 
     public void undo() {
-        int indexToDelete = questionBank.findQuestionIndex(toAdd);
+        int indexToDelete = questionBank.findQuestionIndex(toAddOriginalState);
         questionBank.removeQuestion(indexToDelete);
     }
 
     public String undoMessage() {
-        return String.format("%1$s successfully deleted.", toAdd);
+        return String.format("%1$s successfully deleted.", toAddOriginalState);
     }
 
     public void redo() {
-        questionBank.addQuestionAt(toAddIndex, toAdd);
+        questionBank.addQuestionAt(toAddIndex, toAddOriginalState);
     }
 
     public String redoMessage() {
-        return String.format("%1$s successfully added.", toAdd);
+        return String.format("%1$s successfully added.", toAddOriginalState);
     }
 }


### PR DESCRIPTION
The previous add command stores a qeustion instance which is also stored in the main bank. When edit command is executed, this question is modified and when the edit is undone, the question bank replace that question with a new instance of question that has its original state. Then undo the AddCommand will cause error because the the restored question does not match the question stored in AddCommand class. This issue is now fixed with adding a new attribute to the AddCommand class that stores the original state of the question it added.